### PR TITLE
[fix] Fix CI test failure - Add @ConditionalOnProperty to MailConfig

### DIFF
--- a/src/main/java/com/skax/physicalrisk/config/MailConfig.java
+++ b/src/main/java/com/skax/physicalrisk/config/MailConfig.java
@@ -1,6 +1,7 @@
 package com.skax.physicalrisk.config;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -11,14 +12,15 @@ import java.util.Properties;
 /**
  * 이메일 설정
  *
- * 최종 수정일: 2025-11-13
- * 파일 버전: v01
+ * 최종 수정일: 2025-12-03
+ * 파일 버전: v02
  *
  * 비밀번호 재설정용 이메일 발송 설정
  *
  * @author SKAX Team
  */
 @Configuration
+@ConditionalOnProperty(name = "spring.mail.host")
 public class MailConfig {
 
 	@Value("${spring.mail.host}")


### PR DESCRIPTION
테스트 환경에서 메일 설정이 없어도 애플리케이션이 시작될 수 있도록 MailConfig를 조건부로 로드

주요 변경사항:
- MailConfig에 @ConditionalOnProperty(name = "spring.mail.host") 추가
- EmailService와 동일한 조건부 로드 메커니즘 적용
- CI 환경에서 메일 설정 없이도 테스트 통과 가능

근본 원인:
- MailConfig가 항상 로드되어 @Value로 메일 설정값 주입 시도
- CI 테스트 환경(application-local.yml)에는 메일 설정 없음
- JavaMailSender 빈 생성 실패 → ApplicationContext 로드 실패

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Pull Request

## 1. 작업 내용 요약

이번 PR에서 수행한 작업을 간단하게 작성해주세요.

## 2. 관련 이슈

해당 PR이 해결하는 이슈 번호를 연결해주세요.

- Closes #이슈번호

## 3. 변경 사항

구체적으로 어떤 변경이 있었는지 작성해주세요.

### 기능 추가

-

### 기능 수정

-

### 리팩토링

-

### 버그 수정

-

## 4. 테스트 결과

변경된 내용이 정상적으로 동작함을 확인한 방법을 작성해주세요.

- 단위 테스트 실행 여부
- 통합 테스트 실행 여부
- 로컬 실행 확인 여부

## 5. 관련 자료 (선택)

UI 변경, 로그, 캡처 또는 참고 자료가 있다면 첨부해주세요.

## 6. 체크리스트

- [ ] 브랜치 네이밍 컨벤션 준수
- [ ] 커밋 메시지 컨벤션 준수
- [ ] CI 통과
- [ ] 불필요한 파일 제거
- [ ] 변경 사항에 대한 충분한 설명 작성

## 7. 기타 참고 사항

리뷰어가 알면 좋은 내용이 있다면 작성해주세요.
